### PR TITLE
Fixes for combat after migration to bevy 0.13

### DIFF
--- a/src/game/combat/event_systems.rs
+++ b/src/game/combat/event_systems.rs
@@ -280,14 +280,14 @@ pub fn create_action_infos(
         action_infos.entity = None;
 
         let Ok(player_infos) = query_character_turn.get_single() else { 
-            //println!("create action: No player infos");
+            println!("create action: No player infos");
             return };
         let (entity, action_points, position) = player_infos;
         action_infos.entity = Some(entity);
 
         let tile_position = cursor.grid_position;
         if !board.entity_tiles.contains_key(&tile_position) { 
-            //println!("Create action: out of map");
+            println!("Create action: out of map");
             return }
 
         let mut has_target = false;
@@ -295,7 +295,7 @@ pub fn create_action_infos(
             has_target = true;
             action_infos.target = Some(tile_position);
         }
-        //println!("creation action post has_target: has_target = {:?}, infos.target = {:?}", has_target, action_infos.target);
+        println!("creation action post has_target: has_target = {:?}, infos.target = {:?}", has_target, action_infos.target);
 
         let path_to_destination = find_path(
             position.v,
@@ -306,10 +306,10 @@ pub fn create_action_infos(
         ); 
 
         let Some(path) = path_to_destination else { 
-                //println!("Pas de Path");
+                println!("Pas de Path");
             return };
 
-        //println!("All return checks are done.");
+        println!("All return checks are done.");
         let mut ap_cost = path.len() as u32;
         if has_target {
             let ap_melee_cost = AP_COST_MELEE.saturating_sub(AP_COST_MOVE); // REMEMBER : En melee, le dernier pas est sur la cible donc il faut le retirer.
@@ -321,6 +321,6 @@ pub fn create_action_infos(
             action_infos.path = Some(path);
         };
 
-        //println!("Update action finale: cost: {:?}, path: {:?}, target: {:?}, entity: {:?}", action_infos.cost, action_infos.path, action_infos.target, action_infos.entity);
+        println!("Update action finale: cost: {:?}, path: {:?}, target: {:?}, entity: {:?}", action_infos.cost, action_infos.path, action_infos.target, action_infos.entity);
     }
 }

--- a/src/game/combat/mod.rs
+++ b/src/game/combat/mod.rs
@@ -8,9 +8,7 @@ mod npc_planning_systems;
 use crate::{states::{GameState, EngineState}, game::combat::{components::{ActionPoints, CombatInfos}, events::AnimateEvent}, render::pieces_render::path_animator_update};
 
 use self::{
-    events::{CombatTurnQueue, CombatTurnStartEvent, CombatTurnNextEntityEvent, CombatTurnEndEvent, EntityEndTurnEvent, Turn, EntityMoveEvent, EntityTryMoveEvent, OnClickEvent, EntityHitTryEvent, EntityGetHitEvent, EntityDeathEvent, RefreshActionCostEvent}, 
-    components::CurrentEntityTurnQueue, 
-    event_systems::{action_entity_try_move, action_entity_move, action_entity_end_turn, walk_combat_animation, on_click_action, action_entity_try_attack, action_entity_get_hit, entity_dies, ActionInfos}, npc_planning_systems::npc_planning
+    components::CurrentEntityTurnQueue, event_systems::{action_entity_end_turn, action_entity_get_hit, action_entity_move, action_entity_try_attack, action_entity_try_move, create_action_infos, entity_dies, on_click_action, walk_combat_animation, ActionInfos}, events::{CombatTurnEndEvent, CombatTurnNextEntityEvent, CombatTurnQueue, CombatTurnStartEvent, EntityDeathEvent, EntityEndTurnEvent, EntityGetHitEvent, EntityHitTryEvent, EntityMoveEvent, EntityTryMoveEvent, OnClickEvent, RefreshActionCostEvent, Turn}, npc_planning_systems::npc_planning
 };
 
 use super::{pieces::components::{Health, Stats}, player::{Player, Cursor}, ui::ReloadUiEvent};
@@ -94,7 +92,7 @@ impl Plugin for CombatPlugin {
 
             // Check de la situation PA-wise.
             .add_systems(Update, combat_turn_entity_check.run_if(in_state(GameState::GameMap)).in_set(CombatSet::Logic))
-            // DEACTIVATE 0.13, TO CHECK    // .add_systems(Update, create_action_infos.run_if(resource_exists::<CombatInfos>()).run_if(on_event::<RefreshActionCostEvent>()).in_set(CombatSet::Tick).after(combat_turn_entity_check))
+            .add_systems(Update, create_action_infos.run_if(resource_exists::<CombatInfos>).run_if(on_event::<RefreshActionCostEvent>()).in_set(CombatSet::Tick).after(combat_turn_entity_check))
 
             // ANIME : //TODO : Changer d'endroit.
             .add_systems(Update, walk_combat_animation.run_if(in_state(GameState::GameMap)).in_set(CombatSet::Animation))
@@ -212,15 +210,6 @@ pub fn combat_input(
     mut ev_on_click: EventWriter<OnClickEvent>
 ){
     //println!("Checking if combat input...!");
-    if keys.just_pressed(KeyCode::KeyA) {
-        println!("Appuyé sur A : input OK");
-    }
-    if keys.just_pressed(KeyCode::KeyB) {
-        let Ok(_result) = player_query.get_single() else {
-            println!("Not OK, no entity?");
-            return
-        };
-    }
     if keys.just_pressed(KeyCode::KeyT) {
         let Ok(result) = player_query.get_single() else { return };
         let entity = result;    //result.0 autrefois

--- a/src/game/combat/mod.rs
+++ b/src/game/combat/mod.rs
@@ -205,20 +205,31 @@ pub fn combat_input(
     keys: Res<ButtonInput<KeyCode>>,
     mut ev_endturn: EventWriter<EntityEndTurnEvent>,  
     //mut ev_try_move: EventWriter<EntityTryMoveEvent>,
-    player_query: Query<(Entity, Has<Player>)>,
+    //player_query: Query<(Entity, Has<Player>)>,   // no entity at the end? // TO DELETE?
+    player_query: Query<Entity, With<Player>>,
     buttons: Res<ButtonInput<MouseButton>>,
     res_cursor: Res<Cursor>,    //TODO : On click event?
     mut ev_on_click: EventWriter<OnClickEvent>
 ){
+    //println!("Checking if combat input...!");
+    if keys.just_pressed(KeyCode::KeyA) {
+        println!("Appuyé sur A : input OK");
+    }
+    if keys.just_pressed(KeyCode::KeyB) {
+        let Ok(_result) = player_query.get_single() else {
+            println!("Not OK, no entity?");
+            return
+        };
+    }
     if keys.just_pressed(KeyCode::KeyT) {
         let Ok(result) = player_query.get_single() else { return };
-        let entity = result.0;
+        let entity = result;    //result.0 autrefois
         ev_endturn.send(EntityEndTurnEvent {entity});
-        //println!("Player asked for End of round for {:?}.", entity);
+        println!("Player asked for End of round for {:?}.", entity);
     }
     if buttons.just_released(MouseButton::Left) {
         let Ok(result) = player_query.get_single() else { return };
-        let entity = result.0;
+        let entity = result;    //result.0 autrefois
         let destination = res_cursor.grid_position;
 
         println!("Click !");
@@ -249,7 +260,7 @@ pub fn combat_turn_entity_check(
             let (ap_entity, is_player) = entity_infos;
             //If no AP anymore, next entity turn.
             if ap_entity.current <= 0 {
-                //println!("This entity has no AP: let's turn to next entity event.");
+                println!("This entity has no AP: let's turn to next entity event.");
                 commands.entity(entity).remove::<Turn>();
                 ev_next.send(CombatTurnNextEntityEvent);
            } else if is_player.is_some() {
@@ -259,7 +270,7 @@ pub fn combat_turn_entity_check(
             //println!("This entity has AP but is not the player");
            }
         }
-       // println!("Turn Entity check: {:?} turn.", entity);
+       //println!("Turn Entity check: {:?} turn.", entity);
     }    
 }
 

--- a/src/game/player/cursor.rs
+++ b/src/game/player/cursor.rs
@@ -43,9 +43,9 @@ pub fn cursor_position(
                 res_cursor.grid_position = get_grid_position(world_position.x, world_position.y);
         }
         res_cursor.screen_position = camera.world_to_viewport(camera_transform, res_cursor.world_position);
-        println!("Cursor: World position is : {:?}, Grid position is : {:?}", res_cursor.world_position, res_cursor.grid_position);
+        //println!("Cursor: World position is : {:?}, Grid position is : {:?}", res_cursor.world_position, res_cursor.grid_position);
         let Ok(player_position) = query_player_pos.get_single() else { return };
-        println!("Player Grid Position : {:?}", player_position.v);
+        //println!("Player Grid Position : {:?}", player_position.v);
         //println!("Cursor: Sanity check: get world position is: {:?}", get_world_position(& res_cursor.grid_position));
     }
 }


### PR DESCRIPTION
- [x] Passer son tour
- [x] Action des NPC
- [x] Correct info sur les PA disponibles
- [x] Utilisation de PA pour se deplacer
- [x] Utilisation de PA pour taper
- [x] Perte de PV en accord avec l'attendu.
- [x] Pouvoir tuer un enemi.
- [x] Pouvoir fuir.