### PR TITLE
Tile rendering done well. Or trying to render them well.

### DIFF
--- a/src/game/combat/rules/mod.rs
+++ b/src/game/combat/rules/mod.rs
@@ -30,7 +30,7 @@ pub const NPC_CHANCE_TO_BE_RANGED:i32 = 25; // Percent
 pub const NPC_MAX_DISTANCE_RANGE_FROM_PLAYER_FOR_TURN:i32 = 50; 
 
 // View Range
-pub const VISIBILITY_RANGE_PLAYER:i32 =  10;
+pub const VISIBILITY_RANGE_PLAYER:i32 =  1; //10;
 ///==============================================================================
 
 

--- a/src/game/tileboard/system_map.rs
+++ b/src/game/tileboard/system_map.rs
@@ -17,7 +17,6 @@ pub struct MapInfos{
 }    
 
 // Créer une Map via le Builder. Retourne les elements necessaires au placement des NPC & etc.
-
 pub fn create_map(world: &mut World) -> MapInfos {
     info!("CreateMapMessage: Building Map.");
     println!("CreateMapMessage: Building Map.");

--- a/src/game/visibility/components.rs
+++ b/src/game/visibility/components.rs
@@ -14,11 +14,12 @@ pub struct View {
 
 pub enum ChangeTileVisibilityStatus{
     Visible,
-    Hidden,
-    HiddenButKnown,
+    Hidden
 }
 
 #[derive(Component)]
 pub struct ChangeTileVisibility{
-    pub new_status: ChangeTileVisibilityStatus
+    pub new_status: ChangeTileVisibilityStatus,
+    pub visibility: i32,
+    pub hidden: i32
 }

--- a/src/game/visibility/components.rs
+++ b/src/game/visibility/components.rs
@@ -12,12 +12,13 @@ pub struct View {
     pub range: i32,
 }
 
+#[derive(Debug)]
 pub enum ChangeTileVisibilityStatus{
     Visible,
     Hidden
 }
 
-#[derive(Component)]
+#[derive(Component, Debug)]
 pub struct ChangeTileVisibility{
     pub new_status: ChangeTileVisibilityStatus,
     pub visibility: i32,

--- a/src/game/visibility/mod.rs
+++ b/src/game/visibility/mod.rs
@@ -8,12 +8,13 @@ v1  | 0.20a |
 use bevy::prelude::*;
 
 use crate::game::visibility::components::ComputeFovEvent;
-use self::view_systems::{update_character_view, update_character_view_with_blocked, update_npc_visibility_status, update_tile_visibility_render};
+use self::{view_systems::update_character_view_with_blocked, visibility_render::{update_npc_visibility_status, update_tile_visibility_render}};
 
 use super:: states::GameState;
 
 pub mod components;
 mod view_systems;
+mod visibility_render;
 
  pub struct ViewPlugin;
  

--- a/src/game/visibility/view_systems.rs
+++ b/src/game/visibility/view_systems.rs
@@ -116,7 +116,7 @@ use super::components::{ChangeTileVisibility, ChangeTileVisibilityStatus, View};
         for hiden_tile in to_hide.iter() {
             if board.entity_tiles.contains_key(&Vector2Int {x: hiden_tile.x, y: hiden_tile.y}) {
                 if let Some(tile_logic_entity) = board.entity_tiles.get(&Vector2Int {x: hiden_tile.x, y: hiden_tile.y}) {
-                    commands.entity(*tile_logic_entity).insert(ChangeTileVisibility { new_status: ChangeTileVisibilityStatus::Hidden } );
+                    commands.entity(*tile_logic_entity).insert(ChangeTileVisibility { new_status: ChangeTileVisibilityStatus::Hidden, visibility: 0, hidden: 0 } );
                 }
             }
         }
@@ -134,7 +134,7 @@ use super::components::{ChangeTileVisibility, ChangeTileVisibilityStatus, View};
             //rendre visible.            
             if board.entity_tiles.contains_key(&Vector2Int {x: visible_tile.x, y: visible_tile.y}) {
                 if let Some(tile_logic_entity) = board.entity_tiles.get(&Vector2Int {x: visible_tile.x, y: visible_tile.y}) {
-                    commands.entity(*tile_logic_entity).insert(ChangeTileVisibility { new_status: ChangeTileVisibilityStatus::Visible } );
+                    commands.entity(*tile_logic_entity).insert(ChangeTileVisibility { new_status: ChangeTileVisibilityStatus::Visible, visibility: 0, hidden: 0  } );
                 }
             }
         }

--- a/src/game/visibility/visibility_render.rs
+++ b/src/game/visibility/visibility_render.rs
@@ -91,14 +91,16 @@ const RENDER_SE:(i32, i32) = (1, 0);
 // 0.20h-3 
 // Cas #0 : Range 0 tile = On ne voit rien, pas même la place du joueur.
 // Cas #1 : Range 1 tile = placé sur le joueur. => On voit qq chose.
-// Cas #2 : Range 1 visibility => Est-ce que les bonnes tiles logiques sont marquées comme visibles?
+// Cas #2 : Range 1 visibility => Est-ce que les bonnes tiles logiques sont marquées comme visibles? Oui. J'en ai 9.
+// Cas #2b : Range 1 visibility => les bonnes tiles logiques sont marquées comme devant rester visibles? Oui.
+// Cas #2c : Range 1 visibility => Quand je me deplace, les cases qui ne sont plus visibles sont bien signalées comme hidden? Oui.
 
 pub fn update_tile_visibility_render(
     board: Res<Map>,
     mut commands: Commands,
     mut tile_with_change_order_q: Query<(Entity, &mut ChangeTileVisibility, &BoardPosition), With<Tile>>,
     game_map_render_q: Query<&GameMapRender>, 
-    view_q: Query<&View, With<Player>>,
+    mut view_q: Query<&mut View, With<Player>>,
     mut visibility_q: Query<&mut Visibility>,
     player_position_q: Query<&BoardPosition, With<Player>>,
  ){
@@ -107,10 +109,14 @@ pub fn update_tile_visibility_render(
     println!("Player position is at {:?}", position.v);
     // Je récupère la vue du personnage joueur 
     for view in view_q.iter() {
-        // Je regarde les Logic tiles marquées.
         println!("These logic tiles changed their visibility status.");
         for (entity, new_visibility, position) in tile_with_change_order_q.iter() {
-            println!("{:?}", position.v);
+            // Je regarde les Logic tiles marquées.
+            println!("{:?} : {:?}", position.v, new_visibility.new_status);
+        }
+        println!("My view is :");
+        for logic_tile in &view.visible_tiles[..] {
+            println!("{:?}", logic_tile.clone());
         }
     }
 

--- a/src/game/visibility/visibility_render.rs
+++ b/src/game/visibility/visibility_render.rs
@@ -1,9 +1,9 @@
 // ==> CONCEPTION 0.20h
 /*
 La View du joueur est devenue sale => Il faut mettre à jour.   <== C'est le role de update_character_view_with_blocked.
-
 J'ai la liste des tuiles logiques dans sa view.
-Je determine celles que je dois mettre à jour.  <== Ce n'est pas le role de update_character_view_with_blocked, mais il le fait aujourd'hui.
+Je determine celles que je dois mettre à jour.
+J'indique quelles tuiles logiques doivent changer de statut.
 
 Une nouvelle fonction doit prendre la main.
 A partir des tuiles logiques devant être mise à jour, on determine quelles tuiles render doivent être changées et on gère les doublons avec des ordres contradictoires.
@@ -25,7 +25,7 @@ Si la tile logique SE (x +1, y +1) est visible, alors seule la tuile render SE (
 
 Sauf que d'autres tuiles peuvent donner des informations contradictoires.
 On peut alors donner un score de visibilité à chaque tile render. Si à 1+ alors visible, si à 0- alors Hidden. si au moins un visible => HiddenKnown.
-    */
+*/
 
 use std::cmp;
 
@@ -64,18 +64,578 @@ use super::components::{ChangeTileVisibility, ChangeTileVisibilityStatus, View};
     }
  }
 
-// 0.20h Revision: mise à jour des tiles render.
+ // Par rapport à la tile logic, quelles valeurs x y faut il ajouter pour voir la tuile au N, S, E, W, etc.
+const POS_N: (i32, i32) = (0, -1);
+const POS_NE: (i32, i32) = (1, -1);
+const POS_E: (i32, i32) = (1, 0);
+const POS_SE: (i32, i32) = (1, 1);
+const POS_S: (i32, i32) = (0, 1);
+const POS_SW: (i32, i32) = (-1, 1);
+const POS_W: (i32, i32) = (-1, 0);
+const POS_NW: (i32, i32) = (-1, -1);
+
+// Quelles tuiles logiques determinent le Render de la tuile que l'on consulte.
+// POS_RENDER_NE corresponds au cadre NE d'une tuile. il est donc partagé avec 
+const POS_RENDER_NE:[(i32,i32);3] = [POS_E, POS_NE, POS_N ];
+const POS_RENDER_SE:[(i32,i32);3] = [POS_E, POS_SE, POS_S ];
+const POS_RENDER_SW:[(i32,i32);3] = [POS_W, POS_SW, POS_S ];
+const POS_RENDER_NW:[(i32,i32);3] = [POS_W, POS_NW, POS_N ];
+
+// RENDER_SW corresponds à 0,0.
+const RENDER_SW:(i32, i32) = (0, 0);
+const RENDER_NW:(i32, i32) = (0, -1);
+const RENDER_NE:(i32, i32) = (1, -1);
+const RENDER_SE:(i32, i32) = (1, 0);
+
+
+// 0.20h-3 
+// Cas #0 : Range 0 tile = On ne voit rien, pas même la place du joueur.
+// Cas #1 : Range 1 tile = placé sur le joueur. => On voit qq chose.
+// Cas #2 : Range 1 visibility => Est-ce que les bonnes tiles logiques sont marquées comme visibles?
+
 pub fn update_tile_visibility_render(
     board: Res<Map>,
     mut commands: Commands,
-    tile_with_change_order_q: Query<(Entity, &ChangeTileVisibility, &BoardPosition), With<Tile>>,
+    mut tile_with_change_order_q: Query<(Entity, &mut ChangeTileVisibility, &BoardPosition), With<Tile>>,
     game_map_render_q: Query<&GameMapRender>, 
+    view_q: Query<&View, With<Player>>,
+    mut visibility_q: Query<&mut Visibility>,
+    player_position_q: Query<&BoardPosition, With<Player>>,
+ ){
+    let game_map_render = game_map_render_q.single();
+    let position = player_position_q.single();
+    println!("Player position is at {:?}", position.v);
+    // Je récupère la vue du personnage joueur 
+    for view in view_q.iter() {
+        // Je regarde les Logic tiles marquées.
+        println!("These logic tiles changed their visibility status.");
+        for (entity, new_visibility, position) in tile_with_change_order_q.iter() {
+            println!("{:?}", position.v);
+        }
+    }
+
+    /*
+            
+
+
+
+        // On regarde toutes les tuiles autour.
+        for (x,y) in [POS_N, POS_NE, POS_E, POS_SE, POS_S, POS_SW, POS_W, POS_NW] {
+            for 
+        
+        [RENDER_NE, RENDER_SE, RENDER_SW, RENDER_NW] {
+
+
+
+    let game_map_render = game_map_render_q.single();
+    let position = player_position_q.single();
+    println!("Player position is at {:?}", position.v);
+    for view in view_q.iter() {
+        for (x,y) in [RENDER_NE, RENDER_SE, RENDER_SW, RENDER_NW] {
+            //floor
+            let new_x = position.v.x + x;
+            let new_y = position.v.y + y;
+            println!("We are looking at {x},{y} => position {:?}", (new_x, new_y));
+            if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: new_x, y: position.v.y + y}) {
+                if let Ok(mut visibility) = visibility_q.get_mut(*render_tile_floor_entity){
+                    * visibility = Visibility::Visible;
+                    println!("floor is visible");
+                } else {
+                    println!("No Visibility for entity {:?}", render_tile_floor_entity);
+                }
+            } else {
+                println!("No floor entity for game map render floor at {:?}", (new_x, new_y));
+            }
+            //wall 
+            if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x + x, y: position.v.y + y}) {
+                if let Ok(mut visibility) = visibility_q.get_mut(*render_tile_wall_entity){
+                    * visibility = Visibility::Visible;
+                    println!("Wall is visible");
+                } else {
+                    println!("No render_tile_wall_entity for entity {:?}", render_tile_wall_entity);
+                }
+            } else {
+                println!("No wall entity for game map render floor at {:?}", (new_x, new_y));
+            }
+        }
+    } */
+ }
+
+
+// 0.20h-2 Revision: mise à jour des tiles render.
+// Cas #0 : Range 0 tile = On ne voit rien, pas même la place du joueur.
+// Cas #1 : Range 1 tile = placé sur le joueur. => On voit qq chose.
+// ==> Avec Range 0, on devrait se voir. Et Range 1, on devrait voir à 1 tile.
+pub fn update_tile_visibility_render_v2(
+    board: Res<Map>,
+    mut commands: Commands,
+    mut tile_with_change_order_q: Query<(Entity, &mut ChangeTileVisibility, &BoardPosition), With<Tile>>,
+    game_map_render_q: Query<&GameMapRender>, 
+    view_q: Query<&View, With<Player>>,
     mut visibility_q: Query<&mut Visibility>,
  ){
+    /*A partir des tuiles logiques devant être mise à jour, on determine quelles tuiles render doivent être changées et on gère les doublons avec des ordres contradictoires.
+    On peut partir sur le principe du Mask de la DualGrid => wall_corners
+
+    Je suis la tile logique 10,10 et je dois être visible.
+    Mes équivalents render sont 25% de : 
+        let ne = (x, y) = (10,10)
+        let se = (x, y + 1) = (10,11);
+        let sw = (x - 1, y + 1) = (9,11);
+        let nw = (x - 1, y) = (9,10);
+
+    Je regarde chaque autres tuiles logiques et donne 1 pt si Visible, 0 pt si Hidden.
+    N, E, NE me donnent les points pour Render NE.
+    S, E, SE me donnent les points pour Render SE.
+    S, W, SW me donnent les points pour Render SW.
+    N, W, NW me donnent les points pour Render NW.
+
+    Si j'ai au moins 1 point sur ma tile Render alors je dois être affichée.
+    ==> Ce systeme ne marche que pour les Walls.
+    ==> Avec le floor, il faut une autre règle sinon on affiche une demi floor non visible. Cela ne nous interesse que si nous avons un mur au dessus. TODO
+ 
+    */
+
+    let game_map_render = game_map_render_q.single();
+    // Je récupère la vue du personnage joueur 
+    for view in view_q.iter() {
+        // Je récupère chaque tuile logique concernée par une mise à jour.
+        //let mut rendering_tiles_visible = Vec::new();    // Ici on mets les entity tiles qui devront être hidden.
+        let mut to_remove = Vec::new();
+        let mut render_tile_score: HashMap<Entity, u32> = HashMap::new();
+
+        for (entity, new_visibility, position) in tile_with_change_order_q.iter() {
+            to_remove.push(entity);
+            // Je consulte toutes les tiles logiques autour d'une tuile. On commence avec le NORD.
+            for (x, y) in [POS_N, POS_NE, POS_E, POS_SE, POS_S, POS_SW, POS_W, POS_NW] {
+                // La tuile logique autour (Nor par exemple) est visible.
+                if view.visible_tiles.contains(&Vector2Int { x: position.v.x + x, y: position.v.y + y }) {
+                    // On enregistre ici les Render tile concernées par cette position. 
+                    // Par exemple si on consulte Nord, cela concerne NE & NW. Si on consulte NW, ca concerne NE, NW, W. On enregistre les positions concernées.
+                    let mut render_tiles_covering_positions = Vec::new();
+
+                    if POS_RENDER_NE.contains(&(x,y)) {
+                        render_tiles_covering_positions.push(RENDER_NE);
+                    } 
+                    if POS_RENDER_NW.contains(&(x,y)) {
+                        render_tiles_covering_positions.push(RENDER_NW);
+                    }
+                    if POS_RENDER_SE.contains(&(x,y)) {
+                        render_tiles_covering_positions.push(RENDER_SE);
+                    } 
+                    if POS_RENDER_SW.contains(&(x,y)) {
+                        render_tiles_covering_positions.push(RENDER_SW);
+                    } 
+                    // Il ne devrait pas y avoir de cas où on a pas une Render SW... en théorie?
+
+                    // On monte le score de chacune des tiles concernées.
+                    for render_position in render_tiles_covering_positions {
+                        let (render_x, render_y) = render_position;
+                        //floor
+                        if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x + render_x, y: position.v.y + render_y}) {
+                            if let Some(score) = render_tile_score.get_mut(render_tile_floor_entity) {  // En réalité pas besoin, dés que c'est 1 ça suffit.
+                                *score += 1;
+                            } else {
+                                render_tile_score.insert(*render_tile_floor_entity, 1);
+                            }
+                        }
+                        //wall 
+                        if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x + render_x, y: position.v.y + render_y}) {
+                            if let Some(score) = render_tile_score.get_mut(render_tile_wall_entity) {  // En réalité pas besoin, dés que c'est 1 ça suffit.
+                                *score += 1;
+                            } else {
+                                render_tile_score.insert(*render_tile_wall_entity, 1);
+                            }
+                        }
+                    }
+                }
+                /* 
+                // Iteration #1
+                // Si la tile autour de notre position est visible alors on donne à l'équivalent Render 1 pt.
+                if view.visible_tiles.contains(&Vector2Int { x: position.v.x + x, y: position.v.y + y }) {
+                    let mut render_x: i32;
+                    let mut render_y: i32; 
+
+                    if POS_RENDER_NE.contains(&(x,y)) {
+                        (render_x, render_y) = RENDER_NE;
+                    } else if POS_RENDER_NW.contains(&(x,y)) {
+                        (render_x, render_y) = RENDER_NW;
+                    } else if POS_RENDER_SE.contains(&(x,y)) {
+                        (render_x, render_y) = RENDER_SE;
+                    } else if POS_RENDER_SW.contains(&(x,y)) {
+                        (render_x, render_y) = RENDER_SW;
+                    } else {
+                        continue;   // On devrait d'abord checker ca, puis la visibilité?
+                    }
+
+                    //floor
+                    if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x + render_x, y: position.v.y + render_y}) {
+                        if let Some(score) = render_tile_score.get_mut(render_tile_floor_entity) {  // En réalité pas besoin, dés que c'est 1 ça suffit.
+                            *score += 1;
+                        } else {
+                            render_tile_score.insert(*render_tile_floor_entity, 1);
+                        }
+                    }
+                    //wall 
+                    if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x + render_x, y: position.v.y + render_y}) {
+                        if let Some(score) = render_tile_score.get_mut(render_tile_wall_entity) {  // En réalité pas besoin, dés que c'est 1 ça suffit.
+                            *score += 1;
+                        } else {
+                            render_tile_score.insert(*render_tile_wall_entity, 1);
+                        }
+                    }
+                }
+                */
+            }
+        }
+        for (entity, score) in render_tile_score {
+            if score > 0 {
+                if let Ok(mut visibility) = visibility_q.get_mut(entity){
+                    * visibility = Visibility::Visible
+                }
+            } else {
+                if let Ok(mut visibility) = visibility_q.get_mut(entity){
+                    * visibility = Visibility::Hidden
+                }
+            }
+        }
+    }
+ }
 
 
+            /* 
 
+            // Je consulte une tuile qui doit changer.
+            // Je regarde chaque tuile logique dans l'angle (diagonale):
+            // --> tuile logique au Nord-Ouest (-1, -1) => Render (-1, 0)
+            if view.visible_tiles.contains(&Vector2Int { x: position.v.x -1, y: position.v.y -1}) {  // Est ce que le personnage voit la tile?
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x -1, y: position.v.y }) {
+                    rendering_tiles_visible_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x -1, y: position.v.y }) {
+                    rendering_tiles_visible_wall.push(render_tile_wall_entity);
+                }
+            } else {
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x -1, y: position.v.y }) {
+                    rendering_tiles_hidden_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x -1, y: position.v.y }) {
+                    rendering_tiles_hidden_wall.push(render_tile_wall_entity);
+                }                
+            }
+            // --> Tuile logique au Sud Ouest (-1,+1) => (-1,+1)
+            if view.visible_tiles.contains(&Vector2Int { x: position.v.x -1, y: position.v.y +1}) {  // Est ce que le personnage voit la tile?
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x -1, y: position.v.y +1}) {
+                    rendering_tiles_visible_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x -1, y: position.v.y +1}) {
+                    rendering_tiles_visible_wall.push(render_tile_wall_entity);
+                }
+            } else {
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x -1, y: position.v.y +1 }) {
+                    rendering_tiles_hidden_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x -1, y: position.v.y +1 }) {
+                    rendering_tiles_hidden_wall.push(render_tile_wall_entity);
+                }                
+            }
+            // --> Tuile logique au Nord Est (+1,-1) => Render (0,0)
+            if view.visible_tiles.contains(&Vector2Int { x: position.v.x +1, y: position.v.y -1}) {  // Est ce que le personnage voit la tile?
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x, y: position.v.y}) {
+                    rendering_tiles_visible_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x, y: position.v.y}) {
+                    rendering_tiles_visible_wall.push(render_tile_wall_entity);
+                }
+            } else {
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x, y: position.v.y }) {
+                    rendering_tiles_hidden_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x, y: position.v.y }) {
+                    rendering_tiles_hidden_wall.push(render_tile_wall_entity);
+                }                
+            }
+            // --> Tuile logique au Sud Est (+1,+1) => Render (0, +1)
+            if view.visible_tiles.contains(&Vector2Int { x: position.v.x +1, y: position.v.y +1}) {  // Est ce que le personnage voit la tile?
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x, y: position.v.y +1}) {
+                    rendering_tiles_visible_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x, y: position.v.y +1}) {
+                    rendering_tiles_visible_wall.push(render_tile_wall_entity);
+                }
+            } else {
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x, y: position.v.y +1 }) {
+                    rendering_tiles_hidden_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x, y: position.v.y +1 }) {
+                    rendering_tiles_hidden_wall.push(render_tile_wall_entity);
+                }                
+            }
+        }
 
+        // On donne des scores à chaque entité.
+        let mut score_list: HashMap<Entity, i32> = HashMap::new();
+        for entity in rendering_tiles_visible_floor {
+            if let Some(score) = score_list.get_mut(entity) {
+                *score += 4;
+            } else {
+                score_list.insert(*entity, 2);
+            }
+        }
+        for entity in rendering_tiles_visible_wall {
+            if let Some(score) = score_list.get_mut(entity) {
+                *score += 100;
+            } else {
+                score_list.insert(*entity, 100);
+            }
+        }            
+        for entity in rendering_tiles_hidden_floor {
+            if let Some(score) = score_list.get_mut(entity) {
+                *score -= 1;
+            } else {
+                score_list.insert(*entity, -1);
+            }
+        }
+        for entity in rendering_tiles_hidden_wall {
+            if let Some(score) = score_list.get_mut(entity) {
+                *score -= 1;
+            } else {
+                score_list.insert(*entity, -1);
+            }
+        }
+
+        // On lit les scores et attribue la visibility ou non.
+        for (entity, score) in score_list {
+            if score >= 0 {
+                if let Ok(mut visibility) = visibility_q.get_mut(entity){
+                    * visibility = Visibility::Visible
+                }
+            } else {
+                if let Ok(mut visibility) = visibility_q.get_mut(entity){
+                    * visibility = Visibility::Hidden
+                }
+            }
+        }
+
+        /* 
+        // On prends les entity de la liste et on les passe en visible.
+        for entity in rendering_tiles_visible_floor {
+            if let Ok(mut visibility) = visibility_q.get_mut(*entity){
+                * visibility = Visibility::Visible
+            }
+        }
+        for entity in rendering_tiles_visible_wall {
+            if let Ok(mut visibility) = visibility_q.get_mut(*entity){
+                * visibility = Visibility::Visible
+            }
+        }
+        // Idem pour celles à Hidden NOTE : Hidden se fera en dernier ici.
+        for entity in rendering_tiles_hidden_floor {
+            if let Ok(mut visibility) = visibility_q.get_mut(*entity){
+                * visibility = Visibility::Hidden
+            }
+        }
+        for entity in rendering_tiles_hidden_wall {
+            if let Ok(mut visibility) = visibility_q.get_mut(*entity){
+                * visibility = Visibility::Hidden
+            }
+        }
+        // On remove l'ordre de changer la tile.
+        for entity in to_remove {
+            commands.entity(entity).remove::<ChangeTileVisibility>();
+        }
+        */
+    }
+}
+*/
+
+// 0.20h-1 Revision: mise à jour des tiles render.
+pub fn update_tile_visibility_render_discard(
+    board: Res<Map>,
+    mut commands: Commands,
+    mut tile_with_change_order_q: Query<(Entity, &mut ChangeTileVisibility, &BoardPosition), With<Tile>>,
+    game_map_render_q: Query<&GameMapRender>, 
+    view_q: Query<&View, With<Player>>,
+    mut visibility_q: Query<&mut Visibility>,
+ ){
+    /*A partir des tuiles logiques devant être mise à jour, on determine quelles tuiles render doivent être changées et on gère les doublons avec des ordres contradictoires.
+    On peut partir sur le principe du Mask de la DualGrid => wall_corners
+
+    Je suis la tile logique 10,10 et je dois être visible.
+    Mes équivalents render sont 25% de : 
+        let ne = (x, y) = (10,10)
+        let se = (x, y + 1) = (10,11);
+        let sw = (x - 1, y + 1) = (9,11);
+        let nw = (x - 1, y) = (9,10);
+
+    Comme on doit plutot s'interresser aux angles, on va plutot regarder les tuiles logiques diagonales.
+    Si la tile logique NW (x -1, y -1) est hidden, alors la tuile render NW (x -1, y) de la tuile logique sera hidden.
+    Si la tile logique SW (x -1, y +1) est hidden, alors la tuile render SW (x -1, y +1) de la tuile logique sera hidden.
+    Si la tile logique NE (x +1, y -1) est hidden, alors la tuile render NE (x,y) de la tuile logique sera hidden.
+    Si la tile logique SE (x +1, y +1) est visible, alors seule la tuile render SE (x, y +1) de la tuile logique sera visible. 
+    ==> En representation, cela donnera un angle "tournant".
+
+    Sauf que d'autres tuiles peuvent donner des informations contradictoires.
+    On peut alors donner un score de visibilité à chaque tile render. Si à 1+ alors visible, si à 0- alors Hidden. si au moins un visible => HiddenKnown.
+    */
+
+    let game_map_render = game_map_render_q.single();
+    // Je récupère la vue du personnage joueur 
+    for view in view_q.iter() {
+        // Je récupère chaque tuile logique concernée par une mise à jour.
+        let mut rendering_tiles_visible_floor = Vec::new();    // Ici on mets les entity des tiles qui devront être visibles.
+        let mut rendering_tiles_hidden_floor = Vec::new();    // Ici on mets les entity tiles qui devront être hidden.
+        let mut rendering_tiles_visible_wall = Vec::new();    // Ici on mets les entity des tiles qui devront être visibles.
+        let mut rendering_tiles_hidden_wall = Vec::new();    // Ici on mets les entity tiles qui devront être hidden.
+
+        let mut to_remove = Vec::new();
+
+        for (entity, new_visibility, position) in tile_with_change_order_q.iter() {
+            to_remove.push(entity);
+            // Je consulte une tuile qui doit changer.
+            // Je regarde chaque tuile logique dans l'angle (diagonale):
+            // --> tuile logique au Nord-Ouest (-1, -1) => Render (-1, 0)
+            if view.visible_tiles.contains(&Vector2Int { x: position.v.x -1, y: position.v.y -1}) {  // Est ce que le personnage voit la tile?
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x -1, y: position.v.y }) {
+                    rendering_tiles_visible_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x -1, y: position.v.y }) {
+                    rendering_tiles_visible_wall.push(render_tile_wall_entity);
+                }
+            } else {
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x -1, y: position.v.y }) {
+                    rendering_tiles_hidden_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x -1, y: position.v.y }) {
+                    rendering_tiles_hidden_wall.push(render_tile_wall_entity);
+                }                
+            }
+            // --> Tuile logique au Sud Ouest (-1,+1) => (-1,+1)
+            if view.visible_tiles.contains(&Vector2Int { x: position.v.x -1, y: position.v.y +1}) {  // Est ce que le personnage voit la tile?
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x -1, y: position.v.y +1}) {
+                    rendering_tiles_visible_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x -1, y: position.v.y +1}) {
+                    rendering_tiles_visible_wall.push(render_tile_wall_entity);
+                }
+            } else {
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x -1, y: position.v.y +1 }) {
+                    rendering_tiles_hidden_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x -1, y: position.v.y +1 }) {
+                    rendering_tiles_hidden_wall.push(render_tile_wall_entity);
+                }                
+            }
+            // --> Tuile logique au Nord Est (+1,-1) => Render (0,0)
+            if view.visible_tiles.contains(&Vector2Int { x: position.v.x +1, y: position.v.y -1}) {  // Est ce que le personnage voit la tile?
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x, y: position.v.y}) {
+                    rendering_tiles_visible_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x, y: position.v.y}) {
+                    rendering_tiles_visible_wall.push(render_tile_wall_entity);
+                }
+            } else {
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x, y: position.v.y }) {
+                    rendering_tiles_hidden_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x, y: position.v.y }) {
+                    rendering_tiles_hidden_wall.push(render_tile_wall_entity);
+                }                
+            }
+            // --> Tuile logique au Sud Est (+1,+1) => Render (0, +1)
+            if view.visible_tiles.contains(&Vector2Int { x: position.v.x +1, y: position.v.y +1}) {  // Est ce que le personnage voit la tile?
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x, y: position.v.y +1}) {
+                    rendering_tiles_visible_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x, y: position.v.y +1}) {
+                    rendering_tiles_visible_wall.push(render_tile_wall_entity);
+                }
+            } else {
+                if let Some(render_tile_floor_entity) = game_map_render.floor.get(&Vector2Int { x: position.v.x, y: position.v.y +1 }) {
+                    rendering_tiles_hidden_floor.push(render_tile_floor_entity);
+                }
+                if let Some(render_tile_wall_entity) = game_map_render.wall.get(&Vector2Int { x: position.v.x, y: position.v.y +1 }) {
+                    rendering_tiles_hidden_wall.push(render_tile_wall_entity);
+                }                
+            }
+        }
+
+        // On donne des scores à chaque entité.
+        let mut score_list: HashMap<Entity, i32> = HashMap::new();
+        for entity in rendering_tiles_visible_floor {
+            if let Some(score) = score_list.get_mut(entity) {
+                *score += 4;
+            } else {
+                score_list.insert(*entity, 2);
+            }
+        }
+        for entity in rendering_tiles_visible_wall {
+            if let Some(score) = score_list.get_mut(entity) {
+                *score += 100;
+            } else {
+                score_list.insert(*entity, 100);
+            }
+        }            
+        for entity in rendering_tiles_hidden_floor {
+            if let Some(score) = score_list.get_mut(entity) {
+                *score -= 1;
+            } else {
+                score_list.insert(*entity, -1);
+            }
+        }
+        for entity in rendering_tiles_hidden_wall {
+            if let Some(score) = score_list.get_mut(entity) {
+                *score -= 1;
+            } else {
+                score_list.insert(*entity, -1);
+            }
+        }
+
+        // On lit les scores et attribue la visibility ou non.
+        for (entity, score) in score_list {
+            if score >= 0 {
+                if let Ok(mut visibility) = visibility_q.get_mut(entity){
+                    * visibility = Visibility::Visible
+                }
+            } else {
+                if let Ok(mut visibility) = visibility_q.get_mut(entity){
+                    * visibility = Visibility::Hidden
+                }
+            }
+        }
+
+        /* 
+        // On prends les entity de la liste et on les passe en visible.
+        for entity in rendering_tiles_visible_floor {
+            if let Ok(mut visibility) = visibility_q.get_mut(*entity){
+                * visibility = Visibility::Visible
+            }
+        }
+        for entity in rendering_tiles_visible_wall {
+            if let Ok(mut visibility) = visibility_q.get_mut(*entity){
+                * visibility = Visibility::Visible
+            }
+        }
+        // Idem pour celles à Hidden NOTE : Hidden se fera en dernier ici.
+        for entity in rendering_tiles_hidden_floor {
+            if let Ok(mut visibility) = visibility_q.get_mut(*entity){
+                * visibility = Visibility::Hidden
+            }
+        }
+        for entity in rendering_tiles_hidden_wall {
+            if let Ok(mut visibility) = visibility_q.get_mut(*entity){
+                * visibility = Visibility::Hidden
+            }
+        }
+        // On remove l'ordre de changer la tile.
+        for entity in to_remove {
+            commands.entity(entity).remove::<ChangeTileVisibility>();
+        }
+        */
+    }
+}
+
+/*
     let game_map_render = game_map_render_q.single();
     let mut to_remove = Vec::new();
     let mut tiles_to_change = HashMap::new();   // On place les infos dans ce Hashmap pour eviter les doublons de vector.
@@ -101,7 +661,7 @@ pub fn update_tile_visibility_render(
                 match new_visibility.new_status {
                     ChangeTileVisibilityStatus::Visible => * visibility_floor = Visibility::Visible,
                     ChangeTileVisibilityStatus::Hidden => * visibility_floor = Visibility::Hidden,
-                    ChangeTileVisibilityStatus::HiddenButKnown => {} //* visibility_floor = Visibility::Hidden,
+                    //ChangeTileVisibilityStatus::HiddenButKnown => {} // visibility_floor = Visibility::Hidden,
                 }                
             }                    
         }
@@ -110,15 +670,17 @@ pub fn update_tile_visibility_render(
                 match new_visibility.new_status {
                     ChangeTileVisibilityStatus::Visible => * visibility_wall = Visibility::Visible,
                     ChangeTileVisibilityStatus::Hidden => * visibility_wall = Visibility::Hidden,
-                    ChangeTileVisibilityStatus::HiddenButKnown => {} //* visibility_floor = Visibility::Hidden,
+                    //ChangeTileVisibilityStatus::HiddenButKnown => {} // visibility_floor = Visibility::Hidden,
                 }                
             }                    
         }
     }       
     for entity in to_remove {
         commands.entity(entity).remove::<ChangeTileVisibility>();
-    }
- }
+    } 
+*/
+
+
 
 // 0.20d mise à jour des tiles render.
 pub fn update_tile_visibility_render_older(
@@ -153,7 +715,7 @@ pub fn update_tile_visibility_render_older(
                 match new_visibility.new_status {
                     ChangeTileVisibilityStatus::Visible => * visibility_floor = Visibility::Visible,
                     ChangeTileVisibilityStatus::Hidden => * visibility_floor = Visibility::Hidden,
-                    ChangeTileVisibilityStatus::HiddenButKnown => {} //* visibility_floor = Visibility::Hidden,
+                    //ChangeTileVisibilityStatus::HiddenButKnown => {} //* visibility_floor = Visibility::Hidden,
                 }                
             }                    
         }
@@ -162,7 +724,7 @@ pub fn update_tile_visibility_render_older(
                 match new_visibility.new_status {
                     ChangeTileVisibilityStatus::Visible => * visibility_wall = Visibility::Visible,
                     ChangeTileVisibilityStatus::Hidden => * visibility_wall = Visibility::Hidden,
-                    ChangeTileVisibilityStatus::HiddenButKnown => {} //* visibility_floor = Visibility::Hidden,
+                    //ChangeTileVisibilityStatus::HiddenButKnown => {} //* visibility_floor = Visibility::Hidden,
                 }                
             }                    
         }

--- a/src/game/visibility/visibility_render.rs
+++ b/src/game/visibility/visibility_render.rs
@@ -1,0 +1,197 @@
+// ==> CONCEPTION 0.20h
+/*
+La View du joueur est devenue sale => Il faut mettre à jour.   <== C'est le role de update_character_view_with_blocked.
+
+J'ai la liste des tuiles logiques dans sa view.
+Je determine celles que je dois mettre à jour.  <== Ce n'est pas le role de update_character_view_with_blocked, mais il le fait aujourd'hui.
+
+Une nouvelle fonction doit prendre la main.
+A partir des tuiles logiques devant être mise à jour, on determine quelles tuiles render doivent être changées et on gère les doublons avec des ordres contradictoires.
+On peut partir sur le principe du Mask de la DualGrid => wall_corners
+
+Je suis la tile logique 10,10 et je dois être visible.
+Mes équivalents render sont 25% de : 
+    let ne = (x, y) = (10,10)
+    let se = (x, y + 1) = (10,11);
+    let sw = (x - 1, y + 1) = (9,11);
+    let nw = (x - 1, y) = (9,10);
+
+Comme on doit plutot s'interresser aux angles, on va plutot regarder les tuiles logiques diagonales.
+Si la tile logique NW (x -1, y -1) est hidden, alors la tuile render NW (x -1, y) de la tuile logique sera hidden.
+Si la tile logique SW (x -1, y +1) est hidden, alors la tuile render SW (x -1, y +1) de la tuile logique sera hidden.
+Si la tile logique NE (x +1, y -1) est hidden, alors la tuile render NE (x,y) de la tuile logique sera hidden.
+Si la tile logique SE (x +1, y +1) est visible, alors seule la tuile render SE (x, y +1) de la tuile logique sera visible. 
+==> En representation, cela donnera un angle "tournant".
+
+Sauf que d'autres tuiles peuvent donner des informations contradictoires.
+On peut alors donner un score de visibilité à chaque tile render. Si à 1+ alors visible, si à 0- alors Hidden. si au moins un visible => HiddenKnown.
+    */
+
+use std::cmp;
+
+use bevy::{prelude::*, utils::{HashMap, HashSet}};
+
+use crate::{engine::render::components::GameMapRender, game::{pieces::components::Npc, player::Player, tileboard::components::{BoardPosition, Tile}}, map_builders::map::Map, vectors::Vector2Int};
+
+use super::components::{ChangeTileVisibility, ChangeTileVisibilityStatus, View};
+
+
+
+ // 0.20c Get Entity from game_map_render pour floor ou wall.
+ fn get_floor_entity_at(
+    game_map_render:&GameMapRender,
+    x: i32,
+    y: i32
+ ) -> Option<&Entity> {    
+    if game_map_render.floor.contains_key(&Vector2Int {x, y}) {
+        let option_entity_floor = game_map_render.floor.get(&Vector2Int {x, y});
+        option_entity_floor
+    } else {
+        None
+    }
+ }
+
+ fn get_wall_entity_at(
+    game_map_render:&GameMapRender,
+    x: i32,
+    y: i32
+ ) -> Option<&Entity> {    
+    if game_map_render.wall.contains_key(&Vector2Int {x, y}) {
+        let option_entity_wall = game_map_render.wall.get(&Vector2Int {x, y});
+        option_entity_wall
+    } else {
+        None
+    }
+ }
+
+// 0.20h Revision: mise à jour des tiles render.
+pub fn update_tile_visibility_render(
+    board: Res<Map>,
+    mut commands: Commands,
+    tile_with_change_order_q: Query<(Entity, &ChangeTileVisibility, &BoardPosition), With<Tile>>,
+    game_map_render_q: Query<&GameMapRender>, 
+    mut visibility_q: Query<&mut Visibility>,
+ ){
+
+
+
+
+    let game_map_render = game_map_render_q.single();
+    let mut to_remove = Vec::new();
+    let mut tiles_to_change = HashMap::new();   // On place les infos dans ce Hashmap pour eviter les doublons de vector.
+
+    for (entity, new_visibility, position) in tile_with_change_order_q.iter() {
+        //info!("I have to render the following tiles : {:?}", position.v);
+        // Une tuile logique = 25% d'une tuile graphique x 4 dû au DualGrid. La position x,y corresponds à la partie Nord Ouest de la tuile logique.
+        // Il faut donc aussi traiter x-+1,y ; x, y+1 ; x+1,y+1. On ne doit pas depasser le board non plus.
+        // ===> En fait seul { x: cmp::min(position.v.x + 1, board.width - 1), y: position.v.y} permets d'avoir un affichage propre et ok avec le range. 
+        // Le reste semble s'overdriver et s'écraser mutuellement.
+        
+        //tiles_to_change.insert(Vector2Int { x: position.v.x, y: position.v.x }, new_visibility);
+        //tiles_to_change.insert(Vector2Int { x: cmp::min(position.v.x + 1, board.width - 1), y: cmp::min(position.v.y + 1, board.height - 1)}, new_visibility);
+        //tiles_to_change.insert(Vector2Int { x: position.v.x, y: cmp::min(position.v.y + 1, board.height - 1)}, new_visibility);
+        tiles_to_change.insert(Vector2Int { x: cmp::min(position.v.x + 1, board.width - 1), y: position.v.y}, new_visibility);
+
+        to_remove.push(entity);
+    }
+
+    for (tile_position, new_visibility) in tiles_to_change {
+        if let Some(entity_floor) = get_floor_entity_at(game_map_render, tile_position.x, tile_position.y ) {
+            if let Ok(mut visibility_floor) = visibility_q.get_mut(*entity_floor){
+                match new_visibility.new_status {
+                    ChangeTileVisibilityStatus::Visible => * visibility_floor = Visibility::Visible,
+                    ChangeTileVisibilityStatus::Hidden => * visibility_floor = Visibility::Hidden,
+                    ChangeTileVisibilityStatus::HiddenButKnown => {} //* visibility_floor = Visibility::Hidden,
+                }                
+            }                    
+        }
+        if let Some(entity_wall) = get_wall_entity_at(game_map_render, tile_position.x, tile_position.y ) {
+            if let Ok(mut visibility_wall) = visibility_q.get_mut(*entity_wall){
+                match new_visibility.new_status {
+                    ChangeTileVisibilityStatus::Visible => * visibility_wall = Visibility::Visible,
+                    ChangeTileVisibilityStatus::Hidden => * visibility_wall = Visibility::Hidden,
+                    ChangeTileVisibilityStatus::HiddenButKnown => {} //* visibility_floor = Visibility::Hidden,
+                }                
+            }                    
+        }
+    }       
+    for entity in to_remove {
+        commands.entity(entity).remove::<ChangeTileVisibility>();
+    }
+ }
+
+// 0.20d mise à jour des tiles render.
+pub fn update_tile_visibility_render_older(
+    board: Res<Map>,
+    mut commands: Commands,
+    tile_with_change_order_q: Query<(Entity, &ChangeTileVisibility, &BoardPosition), With<Tile>>,
+    game_map_render_q: Query<&GameMapRender>, 
+    mut visibility_q: Query<&mut Visibility>,
+ ){
+    let game_map_render = game_map_render_q.single();
+    let mut to_remove = Vec::new();
+    let mut tiles_to_change = HashMap::new();   // On place les infos dans ce Hashmap pour eviter les doublons de vector.
+
+    for (entity, new_visibility, position) in tile_with_change_order_q.iter() {
+        //info!("I have to render the following tiles : {:?}", position.v);
+        // Une tuile logique = 25% d'une tuile graphique x 4 dû au DualGrid. La position x,y corresponds à la partie Nord Ouest de la tuile logique.
+        // Il faut donc aussi traiter x-+1,y ; x, y+1 ; x+1,y+1. On ne doit pas depasser le board non plus.
+        // ===> En fait seul { x: cmp::min(position.v.x + 1, board.width - 1), y: position.v.y} permets d'avoir un affichage propre et ok avec le range. 
+        // Le reste semble s'overdriver et s'écraser mutuellement.
+        
+        //tiles_to_change.insert(Vector2Int { x: position.v.x, y: position.v.x }, new_visibility);
+        //tiles_to_change.insert(Vector2Int { x: cmp::min(position.v.x + 1, board.width - 1), y: cmp::min(position.v.y + 1, board.height - 1)}, new_visibility);
+        //tiles_to_change.insert(Vector2Int { x: position.v.x, y: cmp::min(position.v.y + 1, board.height - 1)}, new_visibility);
+        tiles_to_change.insert(Vector2Int { x: cmp::min(position.v.x + 1, board.width - 1), y: position.v.y}, new_visibility);
+
+        to_remove.push(entity);
+    }
+
+    for (tile_position, new_visibility) in tiles_to_change {
+        if let Some(entity_floor) = get_floor_entity_at(game_map_render, tile_position.x, tile_position.y ) {
+            if let Ok(mut visibility_floor) = visibility_q.get_mut(*entity_floor){
+                match new_visibility.new_status {
+                    ChangeTileVisibilityStatus::Visible => * visibility_floor = Visibility::Visible,
+                    ChangeTileVisibilityStatus::Hidden => * visibility_floor = Visibility::Hidden,
+                    ChangeTileVisibilityStatus::HiddenButKnown => {} //* visibility_floor = Visibility::Hidden,
+                }                
+            }                    
+        }
+        if let Some(entity_wall) = get_wall_entity_at(game_map_render, tile_position.x, tile_position.y ) {
+            if let Ok(mut visibility_wall) = visibility_q.get_mut(*entity_wall){
+                match new_visibility.new_status {
+                    ChangeTileVisibilityStatus::Visible => * visibility_wall = Visibility::Visible,
+                    ChangeTileVisibilityStatus::Hidden => * visibility_wall = Visibility::Hidden,
+                    ChangeTileVisibilityStatus::HiddenButKnown => {} //* visibility_floor = Visibility::Hidden,
+                }                
+            }                    
+        }
+    }       
+    for entity in to_remove {
+        commands.entity(entity).remove::<ChangeTileVisibility>();
+    }
+ }
+ 
+  // 0.20e ici on modifie l'affichage. L'intelligence "Je suis pas visible" va dans les autres systèmes.
+  pub fn update_npc_visibility_status(
+    player_view_q: Query<&View, With<Player>>,
+    npc_position_q: Query<(Entity, &BoardPosition), With <Npc>>,
+    mut npc_visibility_q: Query<&mut Visibility, With<Npc>>,
+ ){
+    for view in player_view_q.iter() {
+        let all_npc_positions:&HashSet<(Entity, Vector2Int)> = &npc_position_q.iter().map(|(npc_entity, npc_position)| (npc_entity, npc_position.v)).collect();
+        
+        //info!("My view is : {:?}", view.visible_tiles);
+        for (entity, position) in all_npc_positions{
+            let Ok(mut npc_visibility) = npc_visibility_q.get_mut(*entity) else { continue };
+            if view.visible_tiles.contains(position) {
+                //info!("Entity {:?} is in my view at {:?}", entity, position);                
+                *npc_visibility = Visibility::Visible;
+            } else {
+                //info!("Entity {:?} is not in view sight, because at {:?}", entity, position);
+                *npc_visibility = Visibility::Hidden;
+            }            
+        }
+    }
+ }
+ 

--- a/src/globals.rs
+++ b/src/globals.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 // Versions
-pub const VERSION: &str = "0.20.g";
+pub const VERSION: &str = "0.20.h";
 pub const RELEASE: &str = "R0.4";
 
 // Min - Max VOLUME


### PR DESCRIPTION
# Checker tous les cas de merde pour resoudre le merdier.
- [x] Cas 0: Si je mets en dur une tuile logique à rendre, est-ce que ses 4 render_tiles sont bien affichées? => Oui.
- [ ] Cas 1a : Range 0 tile = On ne voit rien, pas même la place du joueur.
- [ ] Cas 1a : Range 1 tile = placé sur le joueur. => On voit qq chose.
- [x] Cas 2a : Range 1 visibility => Est-ce que les bonnes tiles logiques sont marquées comme visibles? Oui. J'en ai 9.
- [x]  Cas 2b : Range 1 visibility => les bonnes tiles logiques sont marquées comme devant rester visibles? Oui.
- [x] Cas 2c : Range 1 visibility => Quand je me deplace, les cases qui ne sont plus visibles sont bien signalées comme hidden? Oui.

# Analyse
- Je peux faire confiance à la view.visible_entities.
- Je peux faire confiance au component ChangeTileVisibility.

# Clarifier l'attendu.
- Avec un Range de 0, je ne veux rien voir en render, je ne vois que moi.  
- Avec un range de 1, je veux voir ma tile en render et la moitié des tiles autour de moi. Elles apparaissent donc partiellement dans l'ombre, et les NPC y sont visibles et semblent en sortir.  
- Les murs doivent être visibles. En tout cas le premier "layer" du mur. On arrêterait donc la vue après le premier obstacle. Peut-être même un peu plus loin pour ne pas être etouffant (Determiné par l'environnement interieur / exterieur?) Sinon on ne voit jamais que le sol.

# La question qui fache.
A quel point ai-je besoin d'afficher ou non le champ de vision, ou en tout cas à quel point ce doit être précis?  
- Cela a un interêt tactique et suspense : Je ne sais pas ce qu'il y a devant moi, je dois donc faire attention et être prudent si je n'ai pas de visibilité tactique.  
- Un "contre" serait que c'est très claustrophobique. On ne voit que le sol et un peu des murs, mais jamais d'avantage. On peut résoudre cela en ne coupant le champ de vision à la fin de l'obstacle ou après un certain nombre de "layers de murs" traversés. P-e un peu trop spécifique.  
- On peut avoir des drones, des sorts, des schematiques ou autres outils qui permettent d'avoir une visibilité de haut, temporaire ou permanente, plus ou moins précise.  
